### PR TITLE
add support for ARM architecture

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -45,6 +45,11 @@ jobs:
 
       - uses: actions/checkout@v3
 
+      - name: Docker Login
+        id: docker-login
+        run: |
+          docker login -u ${{secrets.DOCKER_USERNAME}} -p ${{secrets.DOCKER_PASSWORD}}
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         if: ${{ steps.compute-tag.outputs.result != 'FALSE' }}
@@ -72,8 +77,11 @@ jobs:
             "RUNTIME_IMAGE=swift:${{ env.SWIFT_VERSION }}-focal"
             "SWIFTLINT_VERSION=${{ env.SWIFTLINT_VERSION }}"
           tags: |
-            ghcr.io/reschandreas/artemis-swift-swiftlint-docker:swift${{ env.SWIFT_VERSION }}
-            ghcr.io/reschandreas/artemis-swift-swiftlint-docker:swiftlint${{ env.SWIFTLINT_VERSION }}
-            ghcr.io/reschandreas/artemis-swift-swiftlint-docker:${{ steps.compute-tag.outputs.result }}
+            ls1tum/artemis-swift-swiftlint-docker:swift${{ env.SWIFT_VERSION }}
+            ls1tum/artemis-swift-swiftlint-docker:swiftlint${{ env.SWIFTLINT_VERSION }}
+            ls1tum/artemis-swift-swiftlint-docker:${{ steps.compute-tag.outputs.result }}
+            ghcr.io/ls1intum/artemis-swift-swiftlint-docker:swift${{ env.SWIFT_VERSION }}
+            ghcr.io/ls1intum/artemis-swift-swiftlint-docker:swiftlint${{ env.SWIFTLINT_VERSION }}
+            ghcr.io/ls1intum/artemis-swift-swiftlint-docker:${{ steps.compute-tag.outputs.result }}
           platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -15,10 +15,14 @@ env:
   SWIFT_VERSION: 5.9.1
   SWIFTLINT_VERSION: 0.53.0
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   buildx:
     name: Build and Push the Docker Images
-    runs-on: ubuntu-latest    
+    runs-on: ubuntu-latest
     steps:
       - name: Compute Tag
         uses: actions/github-script@v6
@@ -38,14 +42,9 @@ jobs:
               }
             }
             return "FALSE";
-      
+
       - uses: actions/checkout@v3
 
-      - name: Docker Login
-        id: docker-login
-        run: |
-          docker login -u ${{secrets.DOCKER_USERNAME}} -p ${{secrets.DOCKER_PASSWORD}}
-      
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         if: ${{ steps.compute-tag.outputs.result != 'FALSE' }}
@@ -55,9 +54,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
+        uses: docker/setup-qemu-action@v3
 
       - name: Install Buildx
         id: buildx
@@ -75,12 +72,8 @@ jobs:
             "RUNTIME_IMAGE=swift:${{ env.SWIFT_VERSION }}-focal"
             "SWIFTLINT_VERSION=${{ env.SWIFTLINT_VERSION }}"
           tags: |
-            ls1tum/artemis-swift-swiftlint-docker:swift${{ env.SWIFT_VERSION }}
-            ls1tum/artemis-swift-swiftlint-docker:swiftlint${{ env.SWIFTLINT_VERSION }}
-            ls1tum/artemis-swift-swiftlint-docker:${{ steps.compute-tag.outputs.result }}
-            ghcr.io/ls1intum/artemis-swift-swiftlint-docker:swift${{ env.SWIFT_VERSION }}
-            ghcr.io/ls1intum/artemis-swift-swiftlint-docker:swiftlint${{ env.SWIFTLINT_VERSION }}
-            ghcr.io/ls1intum/artemis-swift-swiftlint-docker:${{ steps.compute-tag.outputs.result }}
-          platforms: linux/amd64
+            ghcr.io/reschandreas/artemis-swift-swiftlint-docker:swift${{ env.SWIFT_VERSION }}
+            ghcr.io/reschandreas/artemis-swift-swiftlint-docker:swiftlint${{ env.SWIFTLINT_VERSION }}
+            ghcr.io/reschandreas/artemis-swift-swiftlint-docker:${{ steps.compute-tag.outputs.result }}
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update && apt-get install -y \
 RUN git clone https://github.com/realm/SwiftLint.git
 WORKDIR /SwiftLint
 # Defaul SwiftLint version - will be overwritten by the GH action
-ARG SWIFTLINT_VERSION=0.50.0
+ARG SWIFTLINT_VERSION=0.53.0
 RUN git checkout ${SWIFTLINT_VERSION}
 
 RUN swift package update


### PR DESCRIPTION
During my Artemis development I noticed that I could not create/manage any swift exercises due to my computer's architecture. This PR adds the arm image.

The QEMU build takes about 1h and 20 minutes and could fail randomly, but just restart it until it works, it did in my fork.